### PR TITLE
Allocator class stub

### DIFF
--- a/node-express/allocator.js
+++ b/node-express/allocator.js
@@ -4,10 +4,13 @@ class Allocator {
   
   }
 
+  // given a server type ('API', 'DB', etc) return the name of the newly allocated
+  // server (e.g. 'API1', 'API2', 'DB5')
   allocate(serverType) {
 
   }
 
+  // given a server name, remove the server from the pool
   deallocate(serverName) {
     
   }

--- a/node-express/allocator.js
+++ b/node-express/allocator.js
@@ -1,0 +1,17 @@
+class Allocator {
+
+  constructor() {
+  
+  }
+
+  allocate(serverType) {
+
+  }
+
+  deallocate(serverName) {
+    
+  }
+
+}
+
+module.exports = Allocator;

--- a/node-express/allocator.js
+++ b/node-express/allocator.js
@@ -4,8 +4,8 @@ class Allocator {
   
   }
 
-  // given a server type ('API', 'DB', etc) return the name of the newly allocated
-  // server (e.g. 'API1', 'API2', 'DB5')
+  // given a server type ('API', 'DB', etc) allocate a new server and
+  // return the name of the server (e.g. 'API1', 'API2', 'DB5')
   allocate(serverType) {
 
   }

--- a/node-express/index.js
+++ b/node-express/index.js
@@ -2,6 +2,8 @@ const express = require('express');
 const app = express();
 const port = 3000;
 
+const Allocator = require('./allocator');
+
 app.get('/', (req, res) => res.send('Hello World!'));
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`));


### PR DESCRIPTION
We recently had a candidate come into the backend interview set up to work in Ruby on Rails. That's fine and dandy except the candidate leveraged a Postgres database and the Rails ORM to do all of the heavy lifting. I think having such a bare example in this repo can set the wrong expectation coming into the interview, so I've added an `Allocator` class stub here that could hopefully clarify the expectation that we will ignore the web framework for a portion of the interview.

I wanted to also add something like

```javascript
constructor() {
  this.servers = [];
}
```

to emphasize work to be done in-memory, but felt like that might be a bit too suggestive - thoughts?